### PR TITLE
Change cursor positions for-for_in and for_of

### DIFF
--- a/sublime-completions/Miscellaneous.sublime-settings
+++ b/sublime-completions/Miscellaneous.sublime-settings
@@ -51,11 +51,11 @@
     ],
     [
       "for_of",
-      "for (${1:variable} of object) {\n\t${2:// statement}\n}"
+      "for (${1:variable} of ${2:object}) {\n\t${0:// statement}\n}"
     ],
     [
       "for_in",
-      "for (${1:variable} in object) {\n\t${2:// statement}\n}"
+      "for (${1:variable} in ${2:object}) {\n\t${0:// statement}\n}"
     ],
     [
       "do_while",


### PR DESCRIPTION
Most of us usually want to change or edit a name of arrays to iterate over for these two functions.
As for the previous one, we are not able to hit a tab to jump to an array or an object to change its name. It directly jumps to a callback.